### PR TITLE
Update instructions for creating a build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Add this to your `Cargo.toml`:
 ~~~toml
 [build-dependencies]
 gl_generator = "*"
+
+[dependencies]
+gl_common = "*"
 ~~~
 
 Under the `[package]` section, add:


### PR DESCRIPTION
Apparently you need to include a dependency on gl_common now, if you use a build script.