### PR TITLE
Update the khronos API

### DIFF
--- a/src/gl_generator/Cargo.toml
+++ b/src/gl_generator/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.0.3"
 
 [dependencies.khronos_api]
 path = "../khronos_api"
-version = "0.0.4"
+version = "0"
 
 [dependencies]
 log = "*"

--- a/src/khronos_api/Cargo.toml
+++ b/src/khronos_api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "khronos_api"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Corey Richardson",
         "Arseny Kapoulkine",


### PR DESCRIPTION
The diff: https://github.com/capnm/Khronos_XML_API/compare/26330994c92f93330adef22cf0562a2700256689...e9d4cdd8408ec4edc1eff683486d81f7020c3d94

I changed the version in `gl_generator` for it to compile, but I don't think it's worth publishing a new version of gl_generator just for this.