### PR TITLE
Add [build-dependencies.khronos_api]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ path = "src/gl/lib.rs"
 path = "src/gl_generator"
 version = "*"
 
+[build-dependencies.khronos_api]
+path = "src/khronos_api"
+version = "0.0.5"
+
 [dependencies.gl_common]
 path = "src/gl_common"
 version = "0.0.3"


### PR DESCRIPTION
This fixes the build for me on `cargo 0.0.1-pre-nightly (8154255 2015-01-14 19:14:12 +0000)` `rustc 1.0.0-nightly (ed530d7a3 2015-01-16 22:41:16 +0000)`.