### PR TITLE
Fix dependency on khronos_api 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,12 @@ path = "src/gl/lib.rs"
 path = "src/gl_generator"
 version = "*"
 
-[build-dependencies.khronos_api]
-path = "src/khronos_api"
-version = "0.0.5"
-
 [dependencies.gl_common]
 path = "src/gl_common"
 version = "0.0.3"
 
 #[dev-dependencies.glfw]
 #git = "https://github.com/bjz/glfw-rs"
+
+[dependencies]
+khronos_api = "*"


### PR DESCRIPTION
Fix dependency on khronos_api otherwise cargo can't build other projects which have dependency on this project