### PR TITLE
Add a repository to gl_generator Cargo.toml

### DIFF
--- a/src/gl_generator/Cargo.toml
+++ b/src/gl_generator/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Arseny Kapoulkine"
 ]
 description = "Syntax extension for creating bindings to the Khronos OpenGL and related APIs"
+repository = "https://github.com/bjz/gl-rs"
 license = "Apache-2.0"
 
 [lib]


### PR DESCRIPTION
It can be hard to find the origin of this crate in case of fixes and pull requests.