### PR TITLE
Allow merging two Registry objects together

### DIFF
--- a/src/gl_generator/registry.rs
+++ b/src/gl_generator/registry.rs
@@ -23,6 +23,7 @@ use std::collections::BTreeSet;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::collections::HashMap;
+use std::ops::Add;
 use std::fmt;
 use std::str::FromStr;
 use std::slice::Iter;
@@ -153,6 +154,20 @@ impl Registry {
             seen: HashSet::new(),
             iter: self.cmds.iter(),
         }
+    }
+}
+
+impl Add for Registry {
+    type Output = Registry;
+
+    fn add(mut self, other: Registry) -> Registry {
+        self.groups.extend(other.groups.into_iter());
+        self.enums.extend(other.enums.into_iter());
+        self.cmds.extend(other.cmds.into_iter());
+        self.features.extend(other.features.into_iter());
+        self.extensions.extend(other.extensions.into_iter());
+        self.aliases.extend(other.aliases.into_iter());
+        self
     }
 }
 


### PR DESCRIPTION
I need to generate bindings for both OpenGL ES and OpenGL.
Even though the two APIs are very similar, the biggest problem is that the list of available extensions are different.

With this change I could generate a GLES registry, a GL registry, merge them together, and generate the bindings with the result.