### PR TITLE
Changed FromStr for NS

### DIFF
--- a/src/gl_generator/registry.rs
+++ b/src/gl_generator/registry.rs
@@ -49,15 +49,16 @@ impl Ns {
 }
 
 impl FromStr for Ns {
-    fn from_str(s: &str) -> Option<Ns> {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Ns, ()> {
         match s {
-            "gl"  => Some(Gl),
-            "glx" => Some(Glx),
-            "wgl" => Some(Wgl),
-            "egl" => Some(Egl),
-            "gles1" => Some(Gles1),
-            "gles2" => Some(Gles2),
-            _     => None,
+            "gl"  => Ok(Gl),
+            "glx" => Ok(Glx),
+            "wgl" => Ok(Wgl),
+            "egl" => Ok(Egl),
+            "gles1" => Ok(Gles1),
+            "gles2" => Ok(Gles2),
+            _     => Err(()),
         }
     }
 }


### PR DESCRIPTION
Due to stabilization changes to the standard library the FromStr trait now
returns a result.

I made it return the empty tuple as I don't see how anything meaningful could be returned here.