### PR TITLE
Only generate test bindings if we're compiling tests

### DIFF
--- a/src/gl/build.rs
+++ b/src/gl/build.rs
@@ -16,12 +16,10 @@ fn main() {
 
 
     // writing tests files
-    // FIXME (https://github.com/rust-lang/cargo/issues/1058): only build the tests file if
-    //                                                         we run "cargo test"
-    //if os::getenv("PROFILE").unwrap() == "test" {
+    if os::getenv("PROFILE").unwrap() == "test" {
         write_test_gen_symbols(&dest);
         write_test_no_warnings(&dest);
-    //}
+    }
 }
 
 fn write_test_gen_symbols(dest: &Path) {


### PR DESCRIPTION
That should considerably speed up gl-rs's compilation.

Merge one or two days after https://github.com/rust-lang/cargo/pull/1288 is merged