### PR TITLE
Don't use fallbacks when unnecessary.

### DIFF
--- a/src/gl/build.rs
+++ b/src/gl/build.rs
@@ -33,28 +33,35 @@ fn write_test_gen_symbols(dest: &Path) {
                                     khronos_api::GL_XML, vec![], "4.5", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
+    (writeln!(&mut file, "mod gl_compat {{")).unwrap();
+    gl_generator::generate_bindings(gl_generator::GlobalGenerator,
+                                    gl_generator::registry::Ns::Gl,
+                                    khronos_api::GL_XML, vec![], "4.5", "compatibility",
+                                    &mut file).unwrap();
+    (writeln!(&mut file, "}}")).unwrap();
+
     (writeln!(&mut file, "mod gles {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::GlobalGenerator,
                                     gl_generator::registry::Ns::Gles2,
                                     khronos_api::GL_XML, vec![], "3.1", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod glx {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::GlobalGenerator,
                                     gl_generator::registry::Ns::Glx,
                                     khronos_api::GLX_XML, vec![], "1.4", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod wgl {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::GlobalGenerator,
                                     gl_generator::registry::Ns::Wgl,
                                     khronos_api::WGL_XML, vec![], "1.0", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod egl {{ {}", build_egl_symbols())).unwrap();
     gl_generator::generate_bindings(gl_generator::GlobalGenerator,
                                     gl_generator::registry::Ns::Egl,
@@ -65,8 +72,6 @@ fn write_test_gen_symbols(dest: &Path) {
 
 fn write_test_no_warnings(dest: &Path) {
     let mut file = BufferedWriter::new(File::create(&dest.join("test_no_warnings.rs")).unwrap());
-
-
 
     (writeln!(&mut file, "mod gl_global {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::GlobalGenerator,
@@ -81,21 +86,21 @@ fn write_test_no_warnings(dest: &Path) {
                                     khronos_api::GL_XML, vec![], "4.5", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod gl_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StructGenerator,
                                     gl_generator::registry::Ns::Gl,
                                     khronos_api::GL_XML, vec![], "4.5", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod gl_static_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StaticStructGenerator,
                                     gl_generator::registry::Ns::Gl,
                                     khronos_api::GL_XML, vec![], "4.5", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
 
 
     (writeln!(&mut file, "mod glx_global {{")).unwrap();
@@ -111,21 +116,21 @@ fn write_test_no_warnings(dest: &Path) {
                                     khronos_api::GLX_XML, vec![], "1.4", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod glx_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StructGenerator,
                                     gl_generator::registry::Ns::Glx,
                                     khronos_api::GLX_XML, vec![], "1.4", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod glx_static_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StaticStructGenerator,
                                     gl_generator::registry::Ns::Glx,
                                     khronos_api::GLX_XML, vec![], "1.4", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
 
 
     (writeln!(&mut file, "mod wgl_global {{")).unwrap();
@@ -141,21 +146,21 @@ fn write_test_no_warnings(dest: &Path) {
                                     khronos_api::WGL_XML, vec![], "1.0", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod wgl_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StructGenerator,
                                     gl_generator::registry::Ns::Wgl,
                                     khronos_api::WGL_XML, vec![], "1.0", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod wgl_static_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StaticStructGenerator,
                                     gl_generator::registry::Ns::Wgl,
                                     khronos_api::WGL_XML, vec![], "1.0", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
 
 
     (writeln!(&mut file, "mod gles1_global {{")).unwrap();
@@ -171,21 +176,21 @@ fn write_test_no_warnings(dest: &Path) {
                                     khronos_api::GL_XML, vec![], "1.1", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod gles1_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StructGenerator,
                                     gl_generator::registry::Ns::Gles1,
                                     khronos_api::GL_XML, vec![], "1.1", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod gles1_static_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StaticStructGenerator,
                                     gl_generator::registry::Ns::Gles1,
                                     khronos_api::GL_XML, vec![], "1.1", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
 
 
     (writeln!(&mut file, "mod gles2_global {{")).unwrap();
@@ -201,21 +206,21 @@ fn write_test_no_warnings(dest: &Path) {
                                     khronos_api::GL_XML, vec![], "3.1", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod gles2_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StructGenerator,
                                     gl_generator::registry::Ns::Gles2,
                                     khronos_api::GL_XML, vec![], "3.1", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod gles2_static_struct {{")).unwrap();
     gl_generator::generate_bindings(gl_generator::StaticStructGenerator,
                                     gl_generator::registry::Ns::Gles2,
                                     khronos_api::GL_XML, vec![], "3.1", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
 
 
     (writeln!(&mut file, "mod egl_global {{ {}", build_egl_symbols())).unwrap();
@@ -231,21 +236,21 @@ fn write_test_no_warnings(dest: &Path) {
                                     khronos_api::EGL_XML, vec![], "1.5", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod egl_struct {{ {}", build_egl_symbols())).unwrap();
     gl_generator::generate_bindings(gl_generator::StructGenerator,
                                     gl_generator::registry::Ns::Egl,
                                     khronos_api::EGL_XML, vec![], "1.5", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
     (writeln!(&mut file, "mod egl_static_struct {{ {}", build_egl_symbols())).unwrap();
     gl_generator::generate_bindings(gl_generator::StaticStructGenerator,
                                     gl_generator::registry::Ns::Egl,
                                     khronos_api::EGL_XML, vec![], "1.5", "core",
                                     &mut file).unwrap();
     (writeln!(&mut file, "}}")).unwrap();
-    
+
 
 }
 

--- a/src/gl_generator/generators/mod.rs
+++ b/src/gl_generator/generators/mod.rs
@@ -70,11 +70,11 @@ fn gen_enum_item<W>(enm: &Enum, types_prefix: &str, dest: &mut W) -> IoResult<()
         }
     };
 
-    writeln!(dest, "
+    writeln!(dest, "\
         #[stable]
         #[allow(dead_code)]
         #[allow(non_upper_case_globals)]
-        pub const {}: {} = {};
+        pub const {}: {} = {}; \
     ", ident, ty, value)
 }
 

--- a/src/gl_generator/registry.rs
+++ b/src/gl_generator/registry.rs
@@ -496,6 +496,8 @@ impl<R: Buffer> RegistryBuilder<R> {
                     }
                 }
 
+                let aliases = if filter.profile == "core" { HashMap::new() } else { aliases };
+
                 Registry {
                     groups: groups,
                     enums: enums.into_iter().filter(|e| {

--- a/tests/gl_symbols.rs
+++ b/tests/gl_symbols.rs
@@ -1,7 +1,8 @@
 //! This test ensures that the GL symbols are defined and that fallback works correctly.
 
-extern crate gl;
 extern crate libc;
+
+include!(concat!(env!("OUT_DIR"), "/test_gen_symbols.rs"));
 
 #[test]
 #[ignore]
@@ -24,6 +25,6 @@ fn fallback_works() {
         }
     };
 
-    gl::GenFramebuffers::load_with(loader);
-    assert!(gl::GenFramebuffers::is_loaded());
+    gl_compat::GenFramebuffers::load_with(loader);
+    assert!(gl_compat::GenFramebuffers::is_loaded());
 }


### PR DESCRIPTION
Fallbacks don't need to be used (emitted as strings, checked for) when using a core profile.