### PR TITLE
Fix the warnings due to #[stable] and #[unstable] being deprecated

### DIFF
--- a/gl_generator/Cargo.toml
+++ b/gl_generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "gl_generator"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Corey Richardson",
         "Arseny Kapoulkine"

--- a/gl_generator/generators/global_gen.rs
+++ b/gl_generator/generators/global_gen.rs
@@ -71,7 +71,6 @@ fn write_metaloadfn<W>(dest: &mut W) -> io::Result<()> where W: io::Write {
 /// See also `generators::gen_type_aliases`.
 fn write_type_aliases<W>(ns: &Ns, dest: &mut W) -> io::Result<()> where W: io::Write {
     try!(writeln!(dest, r#"
-        #[stable]
         pub mod types {{
             #![allow(non_camel_case_types)]
             #![allow(non_snake_case)]
@@ -106,7 +105,7 @@ fn write_fns<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W: io
         }
 
         try!(writeln!(dest,
-            "#[allow(non_snake_case, unused_variables, dead_code)] #[inline] #[unstable]
+            "#[allow(non_snake_case, unused_variables, dead_code)] #[inline]
             pub unsafe fn {name}({params}) -> {return_suffix} {{ \
                 __gl_imports::mem::transmute::<_, extern \"system\" fn({typed_params}) -> {return_suffix}>\
                     (storage::{name}.f)({idents}) \
@@ -185,7 +184,6 @@ fn write_fn_mods<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()
         let symbol = &symbol[..];
 
         try!(writeln!(dest, r##"
-            #[unstable]
             #[allow(non_snake_case)]
             pub mod {fnname} {{
                 use super::{{storage, metaloadfn}};
@@ -232,7 +230,6 @@ fn write_load_fn<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W
         /// ~~~ignore
         /// gl::load_with(|s| glfw.get_proc_address(s));
         /// ~~~
-        #[unstable]
         #[allow(dead_code)]
         pub fn load_with<F>(mut loadfn: F) where F: FnMut(&str) -> *const __gl_imports::libc::c_void {{
     "));
@@ -250,7 +247,6 @@ fn write_load_fn<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W
         /// ~~~ignore
         /// gl::load(&glfw);
         /// ~~~
-        #[unstable]
         #[allow(dead_code)]
         pub fn load<T: __gl_imports::gl_common::GlFunctionsSource>(loader: &T) {{
             load_with(|name| loader.get_proc_addr(name));

--- a/gl_generator/generators/mod.rs
+++ b/gl_generator/generators/mod.rs
@@ -71,7 +71,6 @@ pub fn gen_enum_item<W>(enm: &Enum, types_prefix: &str, dest: &mut W) -> io::Res
     };
 
     writeln!(dest, "\
-        #[stable]
         #[allow(dead_code)]
         #[allow(non_upper_case_globals)]
         pub const {}: {} = {}; \

--- a/gl_generator/generators/static_gen.rs
+++ b/gl_generator/generators/static_gen.rs
@@ -45,7 +45,6 @@ fn write_header<W>(dest: &mut W) -> io::Result<()> where W: io::Write {
 /// See also `generators::gen_type_aliases`.
 fn write_type_aliases<W>(ns: &Ns, dest: &mut W) -> io::Result<()> where W: io::Write {
     try!(writeln!(dest, r#"
-        #[stable]
         pub mod types {{
             #![allow(non_camel_case_types)]
             #![allow(non_snake_case)]

--- a/gl_generator/generators/static_struct_gen.rs
+++ b/gl_generator/generators/static_struct_gen.rs
@@ -47,7 +47,6 @@ fn write_header<W>(dest: &mut W) -> io::Result<()> where W: io::Write {
 /// See also `generators::gen_type_aliases`.
 fn write_type_aliases<W>(ns: &Ns, dest: &mut W) -> io::Result<()> where W: io::Write {
     try!(writeln!(dest, r#"
-        #[stable]
         pub mod types {{
             #![allow(non_camel_case_types)]
             #![allow(non_snake_case)]
@@ -77,7 +76,6 @@ fn write_struct<W>(ns: &Ns, dest: &mut W) -> io::Result<()> where W: io::Write {
         #[allow(non_camel_case_types)]
         #[allow(non_snake_case)]
         #[allow(dead_code)]
-        #[stable]
         pub struct {ns};",
         ns = ns.fmt_struct_name(),
     )
@@ -88,7 +86,6 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
     try!(writeln!(dest,
         "impl {ns} {{
             /// Stub function.
-            #[unstable]
             #[allow(dead_code)]
             pub fn load_with<F>(mut _loadfn: F) -> {ns} where F: FnMut(&str) -> *const __gl_imports::libc::c_void {{
                 {ns}
@@ -102,7 +99,6 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
             // #[allow(unused_variables)]
             #[allow(dead_code)]
             #[inline]
-            #[unstable]
             pub unsafe fn {name}(&self, {typed_params}) -> {return_suffix} {{
                 {name}({idents})
             }}",

--- a/gl_generator/generators/struct_gen.rs
+++ b/gl_generator/generators/struct_gen.rs
@@ -50,7 +50,6 @@ fn write_header<W>(dest: &mut W) -> io::Result<()> where W: io::Write {
 /// See also `generators::gen_type_aliases`.
 fn write_type_aliases<W>(ns: &Ns, dest: &mut W) -> io::Result<()> where W: io::Write {
     try!(writeln!(dest, r#"
-        #[stable]
         pub mod types {{
             #![allow(non_camel_case_types)]
             #![allow(non_snake_case)]
@@ -130,7 +129,6 @@ fn write_struct<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()>
         #[allow(non_camel_case_types)]
         #[allow(non_snake_case)]
         #[allow(dead_code)]
-        #[stable]
         pub struct {ns} {{",
         ns = ns.fmt_struct_name()
     ));
@@ -155,7 +153,6 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
             /// ~~~ignore
             /// let gl = Gl::load_with(|s| glfw.get_proc_address(s));
             /// ~~~
-            #[unstable]
             #[allow(dead_code)]
             #[allow(unused_variables)]
             pub fn load_with<F>(mut loadfn: F) -> {ns} where F: FnMut(&str) -> *const __gl_imports::libc::c_void {{
@@ -198,7 +195,6 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
         /// ~~~ignore
         /// let gl = Gl::load(&glfw);
         /// ~~~
-        #[unstable]
         #[allow(dead_code)]
         #[allow(unused_variables)]
         pub fn load<T: __gl_imports::gl_common::GlFunctionsSource>(loader: &T) -> {ns} {{
@@ -210,7 +206,7 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
     for c in registry.cmd_iter() {
         try!(writeln!(dest,
             "#[allow(non_snake_case)] #[allow(unused_variables)] #[allow(dead_code)]
-            #[inline] #[unstable] pub unsafe fn {name}(&self, {params}) -> {return_suffix} {{ \
+            #[inline] pub unsafe fn {name}(&self, {params}) -> {return_suffix} {{ \
                 __gl_imports::mem::transmute::<_, extern \"system\" fn({typed_params}) -> {return_suffix}>\
                     (self.{name}.f)({idents}) \
             }}",


### PR DESCRIPTION
Generates thousands of warnings when you compile the generated bindings.