### PR TITLE
Use consts instead of statics in khronos-api

### DIFF
--- a/gl/Cargo.toml
+++ b/gl/Cargo.toml
@@ -18,7 +18,7 @@ version = "*"
 
 [build-dependencies.khronos_api]
 path = "../khronos_api"
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.gl_common]
 path = "../gl_common"

--- a/gl_tests/Cargo.toml
+++ b/gl_tests/Cargo.toml
@@ -10,7 +10,7 @@ version = "*"
 
 [build-dependencies.khronos_api]
 path = "../khronos_api"
-version = "0.0.6"
+version = "0.0.7"
 
 [dependencies.gl_common]
 path = "../gl_common"

--- a/khronos_api/Cargo.toml
+++ b/khronos_api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "khronos_api"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Corey Richardson",
         "Arseny Kapoulkine",

--- a/khronos_api/src/lib.rs
+++ b/khronos_api/src/lib.rs
@@ -1,13 +1,13 @@
 //! This crates contains the sources of the official OpenGL repository.
 
 /// Content of the official `gl.xml` file.
-pub static GL_XML: &'static [u8] = include_bytes!("../api/gl.xml");
+pub const GL_XML: &'static [u8] = include_bytes!("../api/gl.xml");
 
 /// Content of the official `egl.xml` file.
-pub static EGL_XML: &'static [u8] = include_bytes!("../api/egl.xml");
+pub const EGL_XML: &'static [u8] = include_bytes!("../api/egl.xml");
 
 /// Content of the official `wgl.xml` file.
-pub static WGL_XML: &'static [u8] = include_bytes!("../api/wgl.xml");
+pub const WGL_XML: &'static [u8] = include_bytes!("../api/wgl.xml");
 
 /// Content of the official `glx.xml` file.
-pub static GLX_XML: &'static [u8] = include_bytes!("../api/glx.xml");
+pub const GLX_XML: &'static [u8] = include_bytes!("../api/glx.xml");


### PR DESCRIPTION
This is a work-around for https://github.com/rust-lang/rust/issues/26591

Consts are better than statics anyway.
