### PR TITLE
Fix deprecated warning

### DIFF
--- a/gl_generator/generators/debug_struct_gen.rs
+++ b/gl_generator/generators/debug_struct_gen.rs
@@ -138,7 +138,7 @@ fn write_struct<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()>
 
     for c in registry.cmd_iter() {
         if let Some(v) = registry.aliases.get(&c.proto.ident) {
-            try!(writeln!(dest, "/// Fallbacks: {}", v.connect(", ")));
+            try!(writeln!(dest, "/// Fallbacks: {}", v.join(", ")));
         }
         try!(writeln!(dest, "pub {name}: FnPtr,", name = c.proto.ident));
     }
@@ -182,7 +182,7 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
                 Some(fbs) => {
                     fbs.iter()
                        .map(|name| format!("\"{}\"", super::gen_symbol_name(ns, &name)))
-                       .collect::<Vec<_>>().connect(", ")
+                       .collect::<Vec<_>>().join(", ")
                 },
                 None => format!(""),
             },
@@ -211,7 +211,7 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
         let typed_params = super::gen_parameters(c, false, true);
         let println = format!("println!(\"[OpenGL] {}({})\" {});",
                                 c.proto.ident,
-                                (0 .. idents.len()).map(|_| "{:?}".to_string()).collect::<Vec<_>>().connect(", "),
+                                (0 .. idents.len()).map(|_| "{:?}".to_string()).collect::<Vec<_>>().join(", "),
                                 idents.iter().zip(typed_params.iter())
                                       .map(|(name, ty)| {
                                           if ty.contains("GLDEBUGPROC") {
@@ -231,10 +231,10 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
                 r
             }}",
             name = c.proto.ident,
-            params = super::gen_parameters(c, true, true).connect(", "),
-            typed_params = typed_params.connect(", "),
+            params = super::gen_parameters(c, true, true).join(", "),
+            typed_params = typed_params.join(", "),
             return_suffix = super::gen_return_type(c),
-            idents = idents.connect(", "),
+            idents = idents.join(", "),
             println = println,
             print_err = if c.proto.ident != "GetError" && registry.cmd_iter().find(|c| c.proto.ident == "GetError").is_some() {
                 format!(r#"match __gl_imports::mem::transmute::<_, extern "system" fn() -> u32>

--- a/gl_generator/generators/global_gen.rs
+++ b/gl_generator/generators/global_gen.rs
@@ -101,7 +101,7 @@ fn write_enums<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W: 
 fn write_fns<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W: io::Write {
     for c in registry.cmd_iter() {
         if let Some(v) = registry.aliases.get(&c.proto.ident) {
-            try!(writeln!(dest, "/// Fallbacks: {}", v.connect(", ")));
+            try!(writeln!(dest, "/// Fallbacks: {}", v.join(", ")));
         }
 
         try!(writeln!(dest,
@@ -111,10 +111,10 @@ fn write_fns<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W: io
                     (storage::{name}.f)({idents}) \
             }}",
             name = c.proto.ident,
-            params = super::gen_parameters(c, true, true).connect(", "),
-            typed_params = super::gen_parameters(c, false, true).connect(", "),
+            params = super::gen_parameters(c, true, true).join(", "),
+            typed_params = super::gen_parameters(c, false, true).join(", "),
             return_suffix = super::gen_return_type(c),
-            idents = super::gen_parameters(c, true, false).connect(", "),
+            idents = super::gen_parameters(c, true, false).join(", "),
         ));
     }
 
@@ -176,7 +176,7 @@ fn write_fn_mods<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()
         let fallbacks = match registry.aliases.get(&c.proto.ident) {
             Some(v) => {
                 let names = v.iter().map(|name| format!("\"{}\"", super::gen_symbol_name(ns, &name[..]))).collect::<Vec<_>>();
-                format!("&[{}]", names.connect(", "))
+                format!("&[{}]", names.join(", "))
             }, None => "&[]".to_string(),
         };
         let fnname = &c.proto.ident[..];

--- a/gl_generator/generators/static_gen.rs
+++ b/gl_generator/generators/static_gen.rs
@@ -82,7 +82,7 @@ fn write_fns<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> wh
             pub fn {name}({params}) -> {return_suffix};",
             symbol = super::gen_symbol_name(ns, &c.proto.ident),
             name = c.proto.ident,
-            params = super::gen_parameters(c, true, true).connect(", "),
+            params = super::gen_parameters(c, true, true).join(", "),
             return_suffix = super::gen_return_type(c)
         ));
     }

--- a/gl_generator/generators/static_struct_gen.rs
+++ b/gl_generator/generators/static_struct_gen.rs
@@ -104,9 +104,9 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
                 {name}({idents})
             }}",
             name = c.proto.ident,
-            typed_params = super::gen_parameters(c, true, true).connect(", "),
+            typed_params = super::gen_parameters(c, true, true).join(", "),
             return_suffix = super::gen_return_type(c),
-            idents = super::gen_parameters(c, true, false).connect(", "),
+            idents = super::gen_parameters(c, true, false).join(", "),
         ));
     }
 
@@ -129,7 +129,7 @@ fn write_fns<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> wh
             "#[link_name=\"{symbol}\"] fn {name}({params}) -> {return_suffix};",
             symbol = super::gen_symbol_name(ns, &c.proto.ident),
             name = c.proto.ident,
-            params = super::gen_parameters(c, true, true).connect(", "),
+            params = super::gen_parameters(c, true, true).join(", "),
             return_suffix = super::gen_return_type(c)
         ));
     }

--- a/gl_generator/generators/struct_gen.rs
+++ b/gl_generator/generators/struct_gen.rs
@@ -138,7 +138,7 @@ fn write_struct<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()>
 
     for c in registry.cmd_iter() {
         if let Some(v) = registry.aliases.get(&c.proto.ident) {
-            try!(writeln!(dest, "/// Fallbacks: {}", v.connect(", ")));
+            try!(writeln!(dest, "/// Fallbacks: {}", v.join(", ")));
         }
         try!(writeln!(dest, "pub {name}: FnPtr,", name = c.proto.ident));
     }
@@ -182,7 +182,7 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
                 Some(fbs) => {
                     fbs.iter()
                        .map(|name| format!("\"{}\"", super::gen_symbol_name(ns, &name)))
-                       .collect::<Vec<_>>().connect(", ")
+                       .collect::<Vec<_>>().join(", ")
                 },
                 None => format!(""),
             },
@@ -214,10 +214,10 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
                     (self.{name}.f)({idents}) \
             }}",
             name = c.proto.ident,
-            params = super::gen_parameters(c, true, true).connect(", "),
-            typed_params = super::gen_parameters(c, false, true).connect(", "),
+            params = super::gen_parameters(c, true, true).join(", "),
+            typed_params = super::gen_parameters(c, false, true).join(", "),
             return_suffix = super::gen_return_type(c),
-            idents = super::gen_parameters(c, true, false).connect(", "),
+            idents = super::gen_parameters(c, true, false).join(", "),
         ))
     }
 


### PR DESCRIPTION
`connect()` is deprecated in favor of `join()` since Rust 1.3.
I think it's safe to assume that everybody uses Rust 1.3 now.