### PR TITLE
[Breaking Change] Replace libc::c_void with () for function pointer imports

### DIFF
--- a/gl_generator/generators/debug_struct_gen.rs
+++ b/gl_generator/generators/debug_struct_gen.rs
@@ -79,17 +79,17 @@ fn write_fnptr_struct_def<W>(dest: &mut W) -> io::Result<()> where W: io::Write 
         #[derive(Clone)]
         pub struct FnPtr {{
             /// The function pointer that will be used when calling the function.
-            f: *const __gl_imports::libc::c_void,
+            f: *const (),
             /// True if the pointer points to a real function, false if points to a `panic!` fn.
             is_loaded: bool,
         }}
 
         impl FnPtr {{
             /// Creates a `FnPtr` from a load attempt.
-            fn new(ptr: *const __gl_imports::libc::c_void) -> FnPtr {{
+            fn new(ptr: *const ()) -> FnPtr {{
                 if ptr.is_null() {{
                     FnPtr {{
-                        f: missing_fn_panic as *const __gl_imports::libc::c_void,
+                        f: missing_fn_panic as *const (),
                         is_loaded: false
                     }}
                 }} else {{
@@ -157,7 +157,7 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
             /// ~~~
             #[allow(dead_code)]
             #[allow(unused_variables)]
-            pub fn load_with<F>(mut loadfn: F) -> {ns} where F: FnMut(&str) -> *const __gl_imports::libc::c_void {{
+            pub fn load_with<F>(mut loadfn: F) -> {ns} where F: FnMut(&str) -> *const () {{
                 let mut metaloadfn = |symbol: &str, symbols: &[&str]| {{
                     let mut ptr = loadfn(symbol);
                     if ptr.is_null() {{

--- a/gl_generator/generators/static_struct_gen.rs
+++ b/gl_generator/generators/static_struct_gen.rs
@@ -88,7 +88,7 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
         "impl {ns} {{
             /// Stub function.
             #[allow(dead_code)]
-            pub fn load_with<F>(mut _loadfn: F) -> {ns} where F: FnMut(&str) -> *const __gl_imports::libc::c_void {{
+            pub fn load_with<F>(mut _loadfn: F) -> {ns} where F: FnMut(&str) -> *const () {{
                 {ns}
             }}",
         ns = ns.fmt_struct_name(),

--- a/gl_generator/generators/struct_gen.rs
+++ b/gl_generator/generators/struct_gen.rs
@@ -79,17 +79,17 @@ fn write_fnptr_struct_def<W>(dest: &mut W) -> io::Result<()> where W: io::Write 
         #[derive(Clone)]
         pub struct FnPtr {{
             /// The function pointer that will be used when calling the function.
-            f: *const __gl_imports::libc::c_void,
+            f: *const (),
             /// True if the pointer points to a real function, false if points to a `panic!` fn.
             is_loaded: bool,
         }}
 
         impl FnPtr {{
             /// Creates a `FnPtr` from a load attempt.
-            fn new(ptr: *const __gl_imports::libc::c_void) -> FnPtr {{
+            fn new(ptr: *const ()) -> FnPtr {{
                 if ptr.is_null() {{
                     FnPtr {{
-                        f: missing_fn_panic as *const __gl_imports::libc::c_void,
+                        f: missing_fn_panic as *const (),
                         is_loaded: false
                     }}
                 }} else {{
@@ -157,7 +157,7 @@ fn write_impl<W>(registry: &Registry, ns: &Ns, dest: &mut W) -> io::Result<()> w
             /// ~~~
             #[allow(dead_code)]
             #[allow(unused_variables)]
-            pub fn load_with<F>(mut loadfn: F) -> {ns} where F: FnMut(&str) -> *const __gl_imports::libc::c_void {{
+            pub fn load_with<F>(mut loadfn: F) -> {ns} where F: FnMut(&str) -> *const () {{
                 let mut metaloadfn = |symbol: &str, symbols: &[&str]| {{
                     let mut ptr = loadfn(symbol);
                     if ptr.is_null() {{

--- a/gl_tests/tests/gl_symbols.rs
+++ b/gl_tests/tests/gl_symbols.rs
@@ -16,10 +16,10 @@ fn symbols_exist() { unsafe {
 
 #[test]
 fn fallback_works() {
-    fn loader(name: &str) -> *const libc::c_void {
+    fn loader(name: &str) -> *const () {
         match name {
-            "glGenFramebuffers" => 0 as *const libc::c_void,
-            "glGenFramebuffersEXT" => 42 as *const libc::c_void,
+            "glGenFramebuffers" => 0 as *const (),
+            "glGenFramebuffersEXT" => 42 as *const (),
             name => panic!("test tried to load {} unexpectedly!", name)
         }
     };


### PR DESCRIPTION
@tomaka has changed his convention for OpenGL function pointers in `glutin` to use `*const ()` rather then `*const libc::c_void`. I think this is a pretty good idea since it stops people from adding a dependency on `libc` just to glue `glutin`,`glfw`, or `sdl` to `gl-rs`.

This will be a pretty big breaking change, as it effects anything that does OpenGL function loading. But it will save us the pain when `libc 0.3` is released.

cc @bvssvni @bjz @AngryLawyer