### PR TITLE
Revert "Use raw::c_void for GLvoid."

### DIFF
--- a/gl_generator/generators/ty.rs
+++ b/gl_generator/generators/ty.rs
@@ -290,7 +290,7 @@ pub fn build_gl_aliases<W>(dest: &mut W) -> io::Result<()> where W: io::Write {
         "pub type GLenum = super::__gl_imports::raw::c_uint;",
         "pub type GLboolean = super::__gl_imports::raw::c_uchar;",
         "pub type GLbitfield = super::__gl_imports::raw::c_uint;",
-        "pub type GLvoid = super::__gl_imports::raw::c_void;",
+        "pub type GLvoid = ();",
         "pub type GLbyte = super::__gl_imports::raw::c_char;",
         "pub type GLshort = super::__gl_imports::raw::c_short;",
         "pub type GLint = super::__gl_imports::raw::c_int;",


### PR DESCRIPTION
Reverts bjz/gl-rs#372

The docs explicitely say that `c_void` should only be used through pointers: https://doc.rust-lang.org/stable/std/os/raw/enum.c_void.html

`const GLvoid*` and `GLvoid*` are correctly replaced with `*const c_void` and `*mut c_void`, but `GLvoid` itself should be just `()`.
