### PR TITLE
Revert "Revert "Use raw::c_void for GLvoid.""

### DIFF
--- a/gl_generator/generators/ty.rs
+++ b/gl_generator/generators/ty.rs
@@ -290,7 +290,7 @@ pub fn build_gl_aliases<W>(dest: &mut W) -> io::Result<()> where W: io::Write {
         "pub type GLenum = super::__gl_imports::raw::c_uint;",
         "pub type GLboolean = super::__gl_imports::raw::c_uchar;",
         "pub type GLbitfield = super::__gl_imports::raw::c_uint;",
-        "pub type GLvoid = ();",
+        "pub type GLvoid = super::__gl_imports::raw::c_void;",
         "pub type GLbyte = super::__gl_imports::raw::c_char;",
         "pub type GLshort = super::__gl_imports::raw::c_short;",
         "pub type GLint = super::__gl_imports::raw::c_int;",


### PR DESCRIPTION
Reverts bjz/gl-rs#373

Close #375 

After checking, `GLvoid` is never used alone in the OpenGL specs, so I guess it's ok.