### PR TITLE
Api updates

### DIFF
--- a/gl_generator/registry.rs
+++ b/gl_generator/registry.rs
@@ -390,18 +390,18 @@ impl<R: io::Read> RegistryParser<R> {
         for f in features.iter() {
             // XXX: verify that the string comparison with <= actually works as desired
             if f.api == api && f.number <= filter.version {
-                for req in f.requires.iter() {
-                    desired_enums.extend(req.enums.iter().map(|x| x.clone()));
-                    desired_cmds.extend(req.commands.iter().map(|x| x.clone()));
+                for require in f.requires.iter() {
+                    desired_enums.extend(require.enums.iter().map(|x| x.clone()));
+                    desired_cmds.extend(require.commands.iter().map(|x| x.clone()));
                 }
 
-                for rem in f.removes.iter() {
-                    if rem.profile == filter.profile {
-                        for enm in rem.enums.iter() {
+                for remove in f.removes.iter() {
+                    if remove.profile == filter.profile {
+                        for enm in remove.enums.iter() {
                             debug!("Removing {}", enm);
                             desired_enums.remove(enm);
                         }
-                        for cmd in rem.commands.iter() {
+                        for cmd in remove.commands.iter() {
                             debug!("Removing {}", cmd);
                             desired_cmds.remove(cmd);
                         }
@@ -422,9 +422,9 @@ impl<R: io::Read> RegistryParser<R> {
                 if !extension.supported.contains(&api) {
                     panic!("Requested {}, which doesn't support the {} API", extension.name, api);
                 }
-                for req in extension.requires.iter() {
-                    desired_enums.extend(req.enums.iter().map(|x| x.clone()));
-                    desired_cmds.extend(req.commands.iter().map(|x| x.clone()));
+                for require in extension.requires.iter() {
+                    desired_enums.extend(require.enums.iter().map(|x| x.clone()));
+                    desired_cmds.extend(require.commands.iter().map(|x| x.clone()));
                 }
             }
         }

--- a/gl_generator/registry.rs
+++ b/gl_generator/registry.rs
@@ -113,9 +113,9 @@ impl Registry {
 
         let src = match api {
             Api::Gl | Api::GlCore | Api::Gles1 | Api::Gles2 => khronos_api::GL_XML,
-            Api::Glx => self::khronos_api::GLX_XML,
-            Api::Wgl => self::khronos_api::WGL_XML,
-            Api::Egl => self::khronos_api::EGL_XML,
+            Api::Glx => khronos_api::GLX_XML,
+            Api::Wgl => khronos_api::WGL_XML,
+            Api::Egl => khronos_api::EGL_XML,
         };
 
         RegistryParser::parse(src, api, filter)

--- a/gl_generator/registry.rs
+++ b/gl_generator/registry.rs
@@ -394,16 +394,7 @@ impl<R: io::Read> RegistryParser<R> {
                     desired_enums.extend(req.enums.iter().map(|x| x.clone()));
                     desired_cmds.extend(req.commands.iter().map(|x| x.clone()));
                 }
-            }
-            if f.number == filter.version {
-                found_feature = true;
-            }
-        }
 
-        // remove the things that should be removed
-        for f in features.iter() {
-            // XXX: verify that the string comparison with <= actually works as desired
-            if f.api == api && f.number <= filter.version {
                 for rem in f.removes.iter() {
                     if rem.profile == filter.profile {
                         for enm in rem.enums.iter() {
@@ -416,6 +407,9 @@ impl<R: io::Read> RegistryParser<R> {
                         }
                     }
                 }
+            }
+            if f.number == filter.version {
+                found_feature = true;
             }
         }
 

--- a/gl_generator/registry.rs
+++ b/gl_generator/registry.rs
@@ -488,7 +488,7 @@ impl<R: io::Read> RegistryParser<R> {
                 XmlEvent::EndElement{ref name} => {
                     debug!("Found end element </{:?}>", name);
 
-                    if (&[one, two]).iter().any(|&x| x == name.local_name) {
+                    if one == name.local_name || two == name.local_name {
                         continue;
                     } else if "type" == name.local_name {
                         // XXX: GL1.1 contains types, which we never care about anyway.

--- a/gl_tests/test_gen_symbols/build.rs
+++ b/gl_tests/test_gen_symbols/build.rs
@@ -25,28 +25,33 @@ fn main() {
     let mut file = File::create(&Path::new(&dest).join("test_gen_symbols.rs")).unwrap();
 
     writeln!(&mut file, "mod gl {{").unwrap();
-    gl_generator::generate_bindings(GlobalGenerator, Api::Gl, Fallbacks::All,
-                                    vec![], "4.5", Profile::Core, &mut file).unwrap();
+    Registry::new(Api::Gl, (4, 5), Profile::Core, Fallbacks::All, [])
+        .write_bindings(GlobalGenerator, &mut file)
+        .unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gles {{").unwrap();
-    gl_generator::generate_bindings(GlobalGenerator, Api::Gles2, Fallbacks::All,
-                                    vec![], "3.1", Profile::Core, &mut file).unwrap();
+    Registry::new(Api::Gles2, (3, 1), Profile::Core, Fallbacks::All, [])
+        .write_bindings(GlobalGenerator, &mut file)
+        .unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod glx {{").unwrap();
-    gl_generator::generate_bindings(GlobalGenerator, Api::Glx, Fallbacks::All,
-                                    vec![], "1.4", Profile::Core, &mut file).unwrap();
+    Registry::new(Api::Glx, (1, 4), Profile::Core, Fallbacks::All, [])
+        .write_bindings(GlobalGenerator, &mut file)
+        .unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod wgl {{").unwrap();
-    gl_generator::generate_bindings(GlobalGenerator, Api::Wgl, Fallbacks::All,
-                                    vec![], "1.0", Profile::Core, &mut file).unwrap();
+    Registry::new(Api::Wgl, (1, 0), Profile::Core, Fallbacks::All, [])
+        .write_bindings(GlobalGenerator, &mut file)
+        .unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod egl {{ {}", build_egl_symbols()).unwrap();
-    gl_generator::generate_bindings(GlobalGenerator, Api::Egl, Fallbacks::All,
-                                    vec![], "1.5", Profile::Core, &mut file).unwrap();
+    Registry::new(Api::Egl, (1, 5), Profile::Core, Fallbacks::All, [])
+        .write_bindings(GlobalGenerator, &mut file)
+        .unwrap();
     writeln!(&mut file, "}}").unwrap();
 }
 

--- a/gl_tests/test_no_warnings/build.rs
+++ b/gl_tests/test_no_warnings/build.rs
@@ -15,8 +15,6 @@
 extern crate gl_generator;
 
 use gl_generator::*;
-use gl_generator::generators::Generator;
-use gl_generator::registry::Registry;
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
@@ -28,146 +26,146 @@ fn main() {
 
     // Gl
 
-    let gl_registry = Registry::new(Api::Gl, Fallbacks::All, vec![], "4.5", Profile::Core);
+    let gl_registry = Registry::new(Api::Gl, (4, 5), Profile::Core, Fallbacks::All, []);
 
     writeln!(&mut file, "mod gl_global {{").unwrap();
-    GlobalGenerator.write(&gl_registry, &mut file).unwrap();
+    gl_registry.write_bindings(GlobalGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gl_static {{").unwrap();
-    StaticGenerator.write(&gl_registry, &mut file).unwrap();
+    gl_registry.write_bindings(StaticGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gl_struct {{").unwrap();
-    StructGenerator.write(&gl_registry, &mut file).unwrap();
+    gl_registry.write_bindings(StructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gl_static_struct {{").unwrap();
-    StaticStructGenerator.write(&gl_registry, &mut file).unwrap();
+    gl_registry.write_bindings(StaticStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gl_debug_struct {{").unwrap();
-    DebugStructGenerator.write(&gl_registry, &mut file).unwrap();
+    gl_registry.write_bindings(DebugStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     // Glx
 
-    let glx_registry = Registry::new(Api::Glx, Fallbacks::All, vec![], "1.4", Profile::Core);
+    let glx_registry = Registry::new(Api::Glx, (1, 4), Profile::Core, Fallbacks::All, []);
 
     writeln!(&mut file, "mod glx_global {{").unwrap();
-    GlobalGenerator.write(&glx_registry, &mut file).unwrap();
+    glx_registry.write_bindings(GlobalGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod glx_static {{").unwrap();
-    StaticGenerator.write(&glx_registry, &mut file).unwrap();
+    glx_registry.write_bindings(StaticGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod glx_struct {{").unwrap();
-    StructGenerator.write(&glx_registry, &mut file).unwrap();
+    glx_registry.write_bindings(StructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod glx_static_struct {{").unwrap();
-    StaticStructGenerator.write(&glx_registry, &mut file).unwrap();
+    glx_registry.write_bindings(StaticStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod glx_debug_struct {{").unwrap();
-    DebugStructGenerator.write(&glx_registry, &mut file).unwrap();
+    glx_registry.write_bindings(DebugStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     // Wgl
 
-    let wgl_registry = Registry::new(Api::Wgl, Fallbacks::All, vec![], "1.0", Profile::Core);
+    let wgl_registry = Registry::new(Api::Wgl, (1, 0), Profile::Core, Fallbacks::All, []);
 
     writeln!(&mut file, "mod wgl_global {{").unwrap();
-    GlobalGenerator.write(&wgl_registry, &mut file).unwrap();
+    wgl_registry.write_bindings(GlobalGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod wgl_static {{").unwrap();
-    StaticGenerator.write(&wgl_registry, &mut file).unwrap();
+    wgl_registry.write_bindings(StaticGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod wgl_struct {{").unwrap();
-    StructGenerator.write(&wgl_registry, &mut file).unwrap();
+    wgl_registry.write_bindings(StructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod wgl_static_struct {{").unwrap();
-    StaticStructGenerator.write(&wgl_registry, &mut file).unwrap();
+    wgl_registry.write_bindings(StaticStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod wgl_debug_struct {{").unwrap();
-    DebugStructGenerator.write(&wgl_registry, &mut file).unwrap();
+    wgl_registry.write_bindings(DebugStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     // Gles1
 
-    let gles1_registry = Registry::new(Api::Gles1, Fallbacks::All, vec![], "1.1", Profile::Core);
+    let gles1_registry = Registry::new(Api::Gles1, (1, 1), Profile::Core, Fallbacks::All, []);
 
     writeln!(&mut file, "mod gles1_global {{").unwrap();
-    GlobalGenerator.write(&gles1_registry, &mut file).unwrap();
+    gles1_registry.write_bindings(GlobalGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gles1_static {{").unwrap();
-    StaticGenerator.write(&gles1_registry, &mut file).unwrap();
+    gles1_registry.write_bindings(StaticGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gles1_struct {{").unwrap();
-    StructGenerator.write(&gles1_registry, &mut file).unwrap();
+    gles1_registry.write_bindings(StructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gles1_static_struct {{").unwrap();
-    StaticStructGenerator.write(&gles1_registry, &mut file).unwrap();
+    gles1_registry.write_bindings(StaticStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gles1_debug_struct {{").unwrap();
-    DebugStructGenerator.write(&gles1_registry, &mut file).unwrap();
+    gles1_registry.write_bindings(DebugStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     // Gles2
 
-    let gles2_registry = Registry::new(Api::Gles2, Fallbacks::All, vec![], "3.1", Profile::Core);
+    let gles2_registry = Registry::new(Api::Gles2, (3, 1), Profile::Core, Fallbacks::All, []);
 
     writeln!(&mut file, "mod gles2_global {{").unwrap();
-    GlobalGenerator.write(&gles2_registry, &mut file).unwrap();
+    gles2_registry.write_bindings(GlobalGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gles2_static {{").unwrap();
-    StaticGenerator.write(&gles2_registry, &mut file).unwrap();
+    gles2_registry.write_bindings(StaticGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gles2_struct {{").unwrap();
-    StructGenerator.write(&gles2_registry, &mut file).unwrap();
+    gles2_registry.write_bindings(StructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gles2_static_struct {{").unwrap();
-    StaticStructGenerator.write(&gles2_registry, &mut file).unwrap();
+    gles2_registry.write_bindings(StaticStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod gles2_debug_struct {{").unwrap();
-    DebugStructGenerator.write(&gles2_registry, &mut file).unwrap();
+    gles2_registry.write_bindings(DebugStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     // Egl
 
-    let egl_registry = Registry::new(Api::Egl, Fallbacks::All, vec![], "1.5", Profile::Core);
+    let egl_registry = Registry::new(Api::Egl, (1, 5), Profile::Core, Fallbacks::All, []);
 
     writeln!(&mut file, "mod egl_global {{ {}", build_egl_symbols()).unwrap();
-    GlobalGenerator.write(&egl_registry, &mut file).unwrap();
+    egl_registry.write_bindings(GlobalGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod egl_static {{ {}", build_egl_symbols()).unwrap();
-    StaticGenerator.write(&egl_registry, &mut file).unwrap();
+    egl_registry.write_bindings(StaticGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod egl_struct {{ {}", build_egl_symbols()).unwrap();
-    StructGenerator.write(&egl_registry, &mut file).unwrap();
+    egl_registry.write_bindings(StructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod egl_static_struct {{ {}", build_egl_symbols()).unwrap();
-    StaticStructGenerator.write(&egl_registry, &mut file).unwrap();
+    egl_registry.write_bindings(StaticStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 
     writeln!(&mut file, "mod egl_debug_struct {{ {}", build_egl_symbols()).unwrap();
-    DebugStructGenerator.write(&egl_registry, &mut file).unwrap();
+    egl_registry.write_bindings(DebugStructGenerator, &mut file).unwrap();
     writeln!(&mut file, "}}").unwrap();
 }
 

--- a/gl_tests/test_symbols/build.rs
+++ b/gl_tests/test_symbols/build.rs
@@ -23,6 +23,7 @@ fn main() {
     let dest = env::var("OUT_DIR").unwrap();
     let mut file = File::create(&Path::new(&dest).join("test_symbols.rs")).unwrap();
 
-    gl_generator::generate_bindings(GlobalGenerator, Api::Gl, Fallbacks::All,
-                                    vec![], "4.5", Profile::Core, &mut file).unwrap();
+    Registry::new(Api::Gl, (4, 5), Profile::Core, Fallbacks::All, [])
+        .write_bindings(GlobalGenerator, &mut file)
+        .unwrap();
 }

--- a/gl_tests/test_with_extensions/Cargo.toml
+++ b/gl_tests/test_with_extensions/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+# we don't include some metadata to avoid accidental publishes
+name = "test_with_extensions"
+version = "0.0.0"
+build = "build.rs"
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+gl_generator = { path = "../../gl_generator" }

--- a/gl_tests/test_with_extensions/build.rs
+++ b/gl_tests/test_with_extensions/build.rs
@@ -14,16 +14,16 @@
 
 extern crate gl_generator;
 
-use gl_generator::{Registry, Fallbacks, GlobalGenerator, Api, Profile};
+use gl_generator::*;
 use std::env;
 use std::fs::File;
-use std::path::Path;
+use std::path::*;
 
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let mut file = File::create(&Path::new(&out_dir).join("bindings.rs")).unwrap();
+    let dest = env::var("OUT_DIR").unwrap();
+    let mut file = File::create(&Path::new(&dest).join("test_symbols.rs")).unwrap();
 
-    Registry::new(Api::Gl, (4, 5), Profile::Core, Fallbacks::All, [])
+    Registry::new(Api::Gl, (4, 5), Profile::Core, Fallbacks::All, ["GL_ARB_debug_output"])
         .write_bindings(GlobalGenerator, &mut file)
         .unwrap();
 }

--- a/gl_tests/test_with_extensions/lib.rs
+++ b/gl_tests/test_with_extensions/lib.rs
@@ -1,0 +1,47 @@
+// Copyright 2015 Brendan Zabarauskas and the gl-rs developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod gl {
+    include!(concat!(env!("OUT_DIR"), "/test_symbols.rs"));
+}
+
+pub fn compile_test_symbols_exist() {
+        let _ = gl::DebugMessageControlARB;
+        let _ = gl::DebugMessageInsertARB;
+        let _ = gl::DebugMessageCallbackARB;
+        let _ = gl::GetDebugMessageLogARB;
+
+        assert_eq!(gl::DEBUG_OUTPUT_SYNCHRONOUS_ARB,                      0x8242);
+        assert_eq!(gl::MAX_DEBUG_MESSAGE_LENGTH_ARB,                      0x9143);
+        assert_eq!(gl::MAX_DEBUG_LOGGED_MESSAGES_ARB,                     0x9144);
+        assert_eq!(gl::DEBUG_LOGGED_MESSAGES_ARB,                         0x9145);
+        assert_eq!(gl::DEBUG_NEXT_LOGGED_MESSAGE_LENGTH_ARB,              0x8243);
+        assert_eq!(gl::DEBUG_CALLBACK_FUNCTION_ARB,                       0x8244);
+        assert_eq!(gl::DEBUG_CALLBACK_USER_PARAM_ARB,                     0x8245);
+        assert_eq!(gl::DEBUG_SOURCE_API_ARB,                              0x8246);
+        assert_eq!(gl::DEBUG_SOURCE_WINDOW_SYSTEM_ARB,                    0x8247);
+        assert_eq!(gl::DEBUG_SOURCE_SHADER_COMPILER_ARB,                  0x8248);
+        assert_eq!(gl::DEBUG_SOURCE_THIRD_PARTY_ARB,                      0x8249);
+        assert_eq!(gl::DEBUG_SOURCE_APPLICATION_ARB,                      0x824A);
+        assert_eq!(gl::DEBUG_SOURCE_OTHER_ARB,                            0x824B);
+        assert_eq!(gl::DEBUG_TYPE_ERROR_ARB,                              0x824C);
+        assert_eq!(gl::DEBUG_TYPE_DEPRECATED_BEHAVIOR_ARB,                0x824D);
+        assert_eq!(gl::DEBUG_TYPE_UNDEFINED_BEHAVIOR_ARB,                 0x824E);
+        assert_eq!(gl::DEBUG_TYPE_PORTABILITY_ARB,                        0x824F);
+        assert_eq!(gl::DEBUG_TYPE_PERFORMANCE_ARB,                        0x8250);
+        assert_eq!(gl::DEBUG_TYPE_OTHER_ARB,                              0x8251);
+        assert_eq!(gl::DEBUG_SEVERITY_HIGH_ARB,                           0x9146);
+        assert_eq!(gl::DEBUG_SEVERITY_MEDIUM_ARB,                         0x9147);
+        assert_eq!(gl::DEBUG_SEVERITY_LOW_ARB,                            0x9148);
+}


### PR DESCRIPTION
- Use `(u8, u8)` for version number
- Allow extension lists to be any type that satisfies `AsRef<[&str]>`
- Separate parsing and generation stages in API

```rust
Registry::new(Api::Gl, (4, 5), Profile::Core, Fallbacks::All, ["GL_ARB_debug_output"])
    .write_bindings(GlobalGenerator, &mut file)
    .unwrap();
```