### PR TITLE
Move parsing to submodule

### DIFF
--- a/gl_generator/lib.rs
+++ b/gl_generator/lib.rs
@@ -1,5 +1,4 @@
-// Copyright 2013-2014 The gl-rs developers. For a full listing of the authors,
-// refer to the AUTHORS file at the top-level directory of this distribution.
+// Copyright 2015 Brendan Zabarauskas and the gl-rs developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gl_generator/registry/mod.rs
+++ b/gl_generator/registry/mod.rs
@@ -1,0 +1,162 @@
+// Copyright 2013 The gl-rs developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate khronos_api;
+
+use std::collections::BTreeSet;
+use std::collections::HashSet;
+use std::collections::HashMap;
+use std::ops::Add;
+use std::slice::Iter;
+
+use {Fallbacks, Api, Profile};
+
+mod parse;
+
+pub struct Registry {
+    pub api: Api,
+    pub enums: Vec<Enum>,
+    pub cmds: Vec<Cmd>,
+    pub aliases: HashMap<String, Vec<String>>,
+}
+
+impl Registry {
+    pub fn new<'a, Exts>(api: Api, version: (u8, u8), profile: Profile, fallbacks: Fallbacks, extensions: Exts) -> Registry where
+        Exts: AsRef<[&'a str]>,
+    {
+        let (major, minor) = version;
+        let extensions = extensions.as_ref().iter().map(<&str>::to_string).collect();
+
+        let filter = parse::Filter {
+            fallbacks: fallbacks,
+            extensions: extensions,
+            version: format!("{}.{}", major, minor),
+            profile: profile,
+        };
+
+        let src = match api {
+            Api::Gl | Api::GlCore | Api::Gles1 | Api::Gles2 => khronos_api::GL_XML,
+            Api::Glx => khronos_api::GLX_XML,
+            Api::Wgl => khronos_api::WGL_XML,
+            Api::Egl => khronos_api::EGL_XML,
+        };
+
+        parse::RegistryParser::parse(src, api, filter)
+    }
+
+    /// Returns a set of all the types used in the supplied registry. This is useful
+    /// for working out what conversions are needed for the specific registry.
+    pub fn get_tys(&self) -> BTreeSet<String> {
+        let mut tys = BTreeSet::new();
+        for def in self.cmds.iter() {
+            tys.insert(def.proto.ty.clone());
+            for param in def.params.iter() {
+                tys.insert(param.ty.clone());
+            }
+        }
+        tys
+    }
+
+    pub fn enum_iter<'a>(&'a self) -> EnumIterator<'a> {
+        EnumIterator {
+            seen: HashSet::new(),
+            iter: self.enums.iter(),
+        }
+    }
+
+    pub fn cmd_iter<'a>(&'a self) -> CmdIterator<'a> {
+        CmdIterator {
+            seen: HashSet::new(),
+            iter: self.cmds.iter(),
+        }
+    }
+}
+
+impl Add for Registry {
+    type Output = Registry;
+
+    fn add(mut self, other: Registry) -> Registry {
+        self.enums.extend(other.enums.into_iter());
+        self.cmds.extend(other.cmds.into_iter());
+        self.aliases.extend(other.aliases.into_iter());
+        self
+    }
+}
+
+pub struct EnumIterator<'a> {
+    seen: HashSet<String>,
+    iter: Iter<'a, Enum>,
+}
+
+impl<'a> Iterator for EnumIterator<'a> {
+    type Item = &'a Enum;
+
+    fn next(&mut self) -> Option<&'a Enum> {
+        self.iter.next().and_then(|def| {
+            if !self.seen.contains(&def.ident) {
+                self.seen.insert(def.ident.clone());
+                Some(def)
+            } else {
+                self.next()
+            }
+        })
+    }
+}
+
+pub struct CmdIterator<'a> {
+    seen: HashSet<String>,
+    iter: Iter<'a, Cmd>,
+}
+
+impl<'a> Iterator for CmdIterator<'a> {
+    type Item = &'a Cmd;
+
+    fn next(&mut self) -> Option<&'a Cmd> {
+        self.iter.next().and_then(|def| {
+            if !self.seen.contains(&def.proto.ident) {
+                self.seen.insert(def.proto.ident.clone());
+                Some(def)
+            } else {
+                self.next()
+            }
+        })
+    }
+}
+
+pub struct Enum {
+    pub ident: String,
+    pub value: String,
+    pub alias: Option<String>,
+    pub ty: Option<String>,
+}
+
+pub struct Binding {
+    pub ident: String,
+    pub ty: String,
+}
+
+pub struct Cmd {
+    pub proto: Binding,
+    pub params: Vec<Binding>,
+    pub alias: Option<String>,
+    pub vecequiv: Option<String>,
+    pub glx: Option<GlxOpcode>,
+}
+
+pub struct GlxOpcode {
+    pub ty: String,
+    pub opcode: String,
+    pub name: Option<String>,
+}

--- a/gl_generator/registry/mod.rs
+++ b/gl_generator/registry/mod.rs
@@ -1,5 +1,4 @@
-// Copyright 2013 The gl-rs developers. For a full listing of the authors,
-// refer to the AUTHORS file at the top-level directory of this distribution.
+// Copyright 2015 Brendan Zabarauskas and the gl-rs developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gl_generator/registry/parse.rs
+++ b/gl_generator/registry/parse.rs
@@ -20,15 +20,14 @@ use std::collections::hash_map::Entry;
 use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::collections::HashMap;
-use std::ops::Add;
 use std::str::FromStr;
-use std::slice::Iter;
 use std::io;
+use self::xml::attribute::OwnedAttribute;
+use self::xml::EventReader as XmlEventReader;
+use self::xml::reader::XmlEvent;
 
 use {Fallbacks, Api, Profile};
-use self::xml::EventReader as XmlEventReader;
-use self::xml::attribute::OwnedAttribute;
-use self::xml::reader::XmlEvent;
+use registry::{Binding, Cmd, Enum, GlxOpcode, Registry};
 
 impl FromStr for Api {
     type Err = ();
@@ -90,136 +89,6 @@ fn merge_map(a: &mut HashMap<String, Vec<String>>, b: HashMap<String, Vec<String
     }
 }
 
-pub struct Registry {
-    pub api: Api,
-    pub enums: Vec<Enum>,
-    pub cmds: Vec<Cmd>,
-    pub aliases: HashMap<String, Vec<String>>,
-}
-
-impl Registry {
-    pub fn new<'a, Exts>(api: Api, version: (u8, u8), profile: Profile, fallbacks: Fallbacks, extensions: Exts) -> Registry where
-        Exts: AsRef<[&'a str]>,
-    {
-        let (major, minor) = version;
-        let extensions = extensions.as_ref().iter().map(<&str>::to_string).collect();
-
-        let filter = Filter {
-            fallbacks: fallbacks,
-            extensions: extensions,
-            version: format!("{}.{}", major, minor),
-            profile: profile,
-        };
-
-        let src = match api {
-            Api::Gl | Api::GlCore | Api::Gles1 | Api::Gles2 => khronos_api::GL_XML,
-            Api::Glx => khronos_api::GLX_XML,
-            Api::Wgl => khronos_api::WGL_XML,
-            Api::Egl => khronos_api::EGL_XML,
-        };
-
-        RegistryParser::parse(src, api, filter)
-    }
-
-    /// Returns a set of all the types used in the supplied registry. This is useful
-    /// for working out what conversions are needed for the specific registry.
-    pub fn get_tys(&self) -> BTreeSet<String> {
-        let mut tys = BTreeSet::new();
-        for def in self.cmds.iter() {
-            tys.insert(def.proto.ty.clone());
-            for param in def.params.iter() {
-                tys.insert(param.ty.clone());
-            }
-        }
-        tys
-    }
-
-    pub fn enum_iter<'a>(&'a self) -> EnumIterator<'a> {
-        EnumIterator {
-            seen: HashSet::new(),
-            iter: self.enums.iter(),
-        }
-    }
-
-    pub fn cmd_iter<'a>(&'a self) -> CmdIterator<'a> {
-        CmdIterator {
-            seen: HashSet::new(),
-            iter: self.cmds.iter(),
-        }
-    }
-}
-
-impl Add for Registry {
-    type Output = Registry;
-
-    fn add(mut self, other: Registry) -> Registry {
-        self.enums.extend(other.enums.into_iter());
-        self.cmds.extend(other.cmds.into_iter());
-        self.aliases.extend(other.aliases.into_iter());
-        self
-    }
-}
-
-pub struct EnumIterator<'a> {
-    seen: HashSet<String>,
-    iter: Iter<'a, Enum>,
-}
-
-impl<'a> Iterator for EnumIterator<'a> {
-    type Item = &'a Enum;
-
-    fn next(&mut self) -> Option<&'a Enum> {
-        self.iter.next().and_then(|def| {
-            if !self.seen.contains(&def.ident) {
-                self.seen.insert(def.ident.clone());
-                Some(def)
-            } else {
-                self.next()
-            }
-        })
-    }
-}
-
-pub struct CmdIterator<'a> {
-    seen: HashSet<String>,
-    iter: Iter<'a, Cmd>,
-}
-
-impl<'a> Iterator for CmdIterator<'a> {
-    type Item = &'a Cmd;
-
-    fn next(&mut self) -> Option<&'a Cmd> {
-        self.iter.next().and_then(|def| {
-            if !self.seen.contains(&def.proto.ident) {
-                self.seen.insert(def.proto.ident.clone());
-                Some(def)
-            } else {
-                self.next()
-            }
-        })
-    }
-}
-
-pub struct Enum {
-    pub ident: String,
-    pub value: String,
-    pub alias: Option<String>,
-    pub ty: Option<String>,
-}
-
-pub struct Binding {
-    pub ident: String,
-    pub ty: String,
-}
-
-pub struct Cmd {
-    pub proto: Binding,
-    pub params: Vec<Binding>,
-    pub alias: Option<String>,
-    pub vecequiv: Option<String>,
-    pub glx: Option<GlxOpcode>,
-}
-
 #[derive(Clone)]
 struct Feature {
     pub api: Api,
@@ -255,22 +124,16 @@ struct Extension {
     pub requires: Vec<Require>,
 }
 
-pub struct GlxOpcode {
-    pub ty: String,
-    pub opcode: String,
-    pub name: Option<String>,
-}
-
-struct RegistryParser<R: io::Read> {
+pub struct RegistryParser<R: io::Read> {
     api: Api,
     reader: XmlEventReader<R>,
 }
 
-struct Filter {
-    fallbacks: Fallbacks,
-    extensions: BTreeSet<String>,
-    profile: Profile,
-    version: String,
+pub struct Filter {
+    pub fallbacks: Fallbacks,
+    pub extensions: BTreeSet<String>,
+    pub profile: Profile,
+    pub version: String,
 }
 
 /// A big, ugly, imperative impl with methods that accumulates a Registry struct
@@ -323,7 +186,7 @@ impl<R: io::Read> RegistryParser<R> {
         }
     }
 
-    fn parse(src: R, api: Api, filter: Filter) -> Registry {
+    pub fn parse(src: R, api: Api, filter: Filter) -> Registry {
         let mut parser = RegistryParser {
             api: api,
             reader: XmlEventReader::new(src),

--- a/gl_generator/registry/parse.rs
+++ b/gl_generator/registry/parse.rs
@@ -1,5 +1,4 @@
-// Copyright 2013 The gl-rs developers. For a full listing of the authors,
-// refer to the AUTHORS file at the top-level directory of this distribution.
+// Copyright 2015 Brendan Zabarauskas and the gl-rs developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gl_generator/registry/parse.rs
+++ b/gl_generator/registry/parse.rs
@@ -151,14 +151,14 @@ impl<R: io::Read> RegistryParser<R> {
         }
     }
 
-    fn expect_characters(&mut self) -> String {
+    fn consume_characters(&mut self) -> String {
         match self.next() {
             XmlEvent::Characters(ch) => ch,
             msg => panic!("Expected characters, found: {:?}", msg),
         }
     }
 
-    fn expect_start_element(&mut self, n: &str) -> Vec<OwnedAttribute> {
+    fn consume_start_element(&mut self, n: &str) -> Vec<OwnedAttribute> {
         match self.next() {
             XmlEvent::StartElement { name, attributes, .. } => {
                 if n == name.local_name { attributes } else {
@@ -169,7 +169,7 @@ impl<R: io::Read> RegistryParser<R> {
         }
     }
 
-    fn expect_end_element(&mut self, n: &str) {
+    fn consume_end_element(&mut self, n: &str) {
         match self.next() {
             XmlEvent::EndElement { ref name } if n == name.local_name => (),
             msg => panic!("Expected </{}>, found: {:?}", n, msg),
@@ -192,7 +192,7 @@ impl<R: io::Read> RegistryParser<R> {
             reader: XmlEventReader::new(src),
         };
 
-        parser.expect_start_element("registry");
+        parser.consume_start_element("registry");
 
         let mut enums = Vec::new();
         let mut cmds = Vec::new();
@@ -381,7 +381,7 @@ impl<R: io::Read> RegistryParser<R> {
                             ty:     get_attribute(&attributes, "type"),
                         }
                     );
-                    self.expect_end_element("enum");
+                    self.consume_end_element("enum");
                 }
 
                 // finished building the namespace
@@ -420,7 +420,7 @@ impl<R: io::Read> RegistryParser<R> {
 
     fn consume_cmd(&mut self) -> Cmd {
         // consume command prototype
-        self.expect_start_element("proto");
+        self.consume_start_element("proto");
         let mut proto = self.consume_binding("proto");
         proto.ident = trim_cmd_prefix(&proto.ident, self.api).to_string();
 
@@ -436,11 +436,11 @@ impl<R: io::Read> RegistryParser<R> {
                 XmlEvent::StartElement{ref name, ref attributes, ..} if name.local_name == "alias" => {
                     alias = get_attribute(&attributes, "name");
                     alias = alias.map(|t| trim_cmd_prefix(&t, self.api).to_string());
-                    self.expect_end_element("alias");
+                    self.consume_end_element("alias");
                 }
                 XmlEvent::StartElement{ref name, ref attributes, ..} if name.local_name == "vecequiv" => {
                     vecequiv = get_attribute(&attributes, "vecequiv");
-                    self.expect_end_element("vecequiv");
+                    self.consume_end_element("vecequiv");
                 }
                 XmlEvent::StartElement{ref name, ref attributes, ..} if name.local_name == "glx" => {
                     glx = Some(GlxOpcode {
@@ -448,7 +448,7 @@ impl<R: io::Read> RegistryParser<R> {
                         opcode: get_attribute(&attributes, "opcode").unwrap(),
                         name: get_attribute(&attributes, "name"),
                     });
-                    self.expect_end_element("glx");
+                    self.consume_end_element("glx");
                 }
                 XmlEvent::EndElement{ref name} if name.local_name == "command" => break,
                 msg => panic!("Expected </command>, found: {:?}", msg),
@@ -478,8 +478,8 @@ impl<R: io::Read> RegistryParser<R> {
         }
 
         // consume identifier
-        let ident = self.expect_characters();
-        self.expect_end_element("name");
+        let ident = self.consume_characters();
+        self.consume_end_element("name");
 
         // consume the type suffix
         loop {

--- a/gl_generator/registry/parse.rs
+++ b/gl_generator/registry/parse.rs
@@ -20,7 +20,6 @@ use std::collections::hash_map::Entry;
 use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::io;
 use self::xml::attribute::OwnedAttribute;
 use self::xml::EventReader as XmlEventReader;
@@ -29,32 +28,24 @@ use self::xml::reader::XmlEvent;
 use {Fallbacks, Api, Profile};
 use registry::{Binding, Cmd, Enum, GlxOpcode, Registry};
 
-impl FromStr for Api {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Api, ()> {
-        match s {
-            "gl" => Ok(Api::Gl),
-            "glx" => Ok(Api::Glx),
-            "wgl" => Ok(Api::Wgl),
-            "egl" => Ok(Api::Egl),
-            "glcore" => Ok(Api::GlCore),
-            "gles1" => Ok(Api::Gles1),
-            "gles2" => Ok(Api::Gles2),
-            _     => Err(()),
-        }
+fn api_from_str(src: &str) -> Result<Api, ()> {
+    match src {
+        "gl" => Ok(Api::Gl),
+        "glx" => Ok(Api::Glx),
+        "wgl" => Ok(Api::Wgl),
+        "egl" => Ok(Api::Egl),
+        "glcore" => Ok(Api::GlCore),
+        "gles1" => Ok(Api::Gles1),
+        "gles2" => Ok(Api::Gles2),
+        _     => Err(()),
     }
 }
 
-impl FromStr for Profile {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Profile, ()> {
-        match s {
-            "core" => Ok(Profile::Core),
-            "compatibility" => Ok(Profile::Compatibility),
-            _ => Err(()),
-        }
+fn profile_from_str(src: &str) -> Result<Profile, ()> {
+    match src {
+        "core" => Ok(Profile::Core),
+        "compatibility" => Ok(Profile::Compatibility),
+        _ => Err(()),
     }
 }
 
@@ -520,7 +511,7 @@ impl FromXml for Remove {
     fn convert<R: io::Read>(r: &mut RegistryParser<R>, a: &[OwnedAttribute]) -> Remove {
         debug!("Doing a FromXml on Remove");
         let profile = get_attribute(a, "profile").unwrap();
-        let profile = Profile::from_str(&*profile).unwrap();
+        let profile = profile_from_str(&profile).unwrap();
         let (enums, commands) = r.consume_two("enum", "command", "remove");
 
         Remove {
@@ -535,7 +526,7 @@ impl FromXml for Feature {
     fn convert<R: io::Read>(r: &mut RegistryParser<R>, a: &[OwnedAttribute]) -> Feature {
         debug!("Doing a FromXml on Feature");
         let api = get_attribute(a, "api").unwrap();
-        let api = Api::from_str(&*api).unwrap();
+        let api = api_from_str(&api).unwrap();
         let name = get_attribute(a, "name").unwrap();
         let number = get_attribute(a, "number").unwrap();
 
@@ -559,7 +550,7 @@ impl FromXml for Extension {
         let name = get_attribute(a, "name").unwrap();
         let supported = get_attribute(a, "supported").unwrap()
             .split('|')
-            .map(|x| Api::from_str(x))
+            .map(api_from_str)
             .map(Result::unwrap)
             .collect::<Vec<_>>();
         let mut require = Vec::new();


### PR DESCRIPTION
This should make it easier to distinguish between the layout of the public registry types, and the private parser implementation.