### PR TITLE
Narrow events from xml parser to simplify parsing

### DIFF
--- a/gl_generator/lib.rs
+++ b/gl_generator/lib.rs
@@ -62,6 +62,7 @@
 
 #[macro_use]
 extern crate log;
+extern crate xml;
 
 use generators::Generator;
 

--- a/gl_generator/registry/mod.rs
+++ b/gl_generator/registry/mod.rs
@@ -41,6 +41,7 @@ impl Registry {
             .collect();
 
         let filter = parse::Filter {
+            api: api,
             fallbacks: fallbacks,
             extensions: extensions,
             version: format!("{}.{}", major, minor),
@@ -54,7 +55,7 @@ impl Registry {
             Api::Egl => khronos_api::EGL_XML,
         };
 
-        parse::RegistryParser::parse(src, api, filter)
+        parse::RegistryParser::parse(src, filter)
     }
 
     /// Returns a set of all the types used in the supplied registry. This is useful

--- a/gl_generator/registry/mod.rs
+++ b/gl_generator/registry/mod.rs
@@ -55,7 +55,7 @@ impl Registry {
             Api::Egl => khronos_api::EGL_XML,
         };
 
-        parse::RegistryParser::parse(src, filter)
+        parse::from_xml(src, filter)
     }
 
     /// Returns a set of all the types used in the supplied registry. This is useful


### PR DESCRIPTION
Working with the raw types from the `xml` crate requires lots of busy-work. This PR converts the `XmlEvent`s over to a simpler `ParseEvent` type that throws out the stuff that we don't need. It also removes the `RegistryParser`, implementing an extension trait on `ParseEvent` iterators instead.