### PR TITLE
Move types back to registry

### DIFF
--- a/gl_generator/lib.rs
+++ b/gl_generator/lib.rs
@@ -64,50 +64,14 @@
 extern crate log;
 extern crate xml;
 
-use generators::Generator;
+pub mod generators;
+mod registry;
 
-use std::fmt;
-use std::io;
-
-pub use registry::Registry;
+pub use generators::Generator;
 pub use generators::debug_struct_gen::DebugStructGenerator;
 pub use generators::global_gen::GlobalGenerator;
 pub use generators::static_gen::StaticGenerator;
 pub use generators::static_struct_gen::StaticStructGenerator;
 pub use generators::struct_gen::StructGenerator;
 
-pub mod generators;
-pub mod registry;
-
-
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub enum Api { Gl, Glx, Wgl, Egl, GlCore, Gles1, Gles2 }
-
-impl fmt::Display for Api {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Api::Gl  => write!(fmt, "gl"),
-            Api::Glx => write!(fmt, "glx"),
-            Api::Wgl => write!(fmt, "wgl"),
-            Api::Egl => write!(fmt, "egl"),
-            Api::GlCore => write!(fmt, "glcore"),
-            Api::Gles1 => write!(fmt, "gles1"),
-            Api::Gles2 => write!(fmt, "gles2"),
-        }
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub enum Fallbacks { All, None }
-
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub enum Profile { Core, Compatibility }
-
-impl Registry {
-    pub fn write_bindings<W, G>(&self, generator: G, output: &mut W) -> io::Result<()> where
-        G: Generator,
-        W: io::Write,
-    {
-        generator.write(&self, output)
-    }
-}
+pub use registry::*;

--- a/gl_generator/registry/mod.rs
+++ b/gl_generator/registry/mod.rs
@@ -17,12 +17,63 @@ extern crate khronos_api;
 use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::collections::HashMap;
+use std::fmt;
+use std::io;
 use std::ops::Add;
 use std::slice::Iter;
 
-use {Fallbacks, Api, Profile};
+use Generator;
 
 mod parse;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Api { Gl, Glx, Wgl, Egl, GlCore, Gles1, Gles2 }
+
+impl fmt::Display for Api {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Api::Gl  => write!(fmt, "gl"),
+            Api::Glx => write!(fmt, "glx"),
+            Api::Wgl => write!(fmt, "wgl"),
+            Api::Egl => write!(fmt, "egl"),
+            Api::GlCore => write!(fmt, "glcore"),
+            Api::Gles1 => write!(fmt, "gles1"),
+            Api::Gles2 => write!(fmt, "gles2"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Fallbacks { All, None }
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Profile { Core, Compatibility }
+
+pub struct Enum {
+    pub ident: String,
+    pub value: String,
+    pub alias: Option<String>,
+    pub ty: Option<String>,
+}
+
+pub struct Binding {
+    pub ident: String,
+    pub ty: String,
+}
+
+pub struct Cmd {
+    pub proto: Binding,
+    pub params: Vec<Binding>,
+    pub alias: Option<String>,
+    pub vecequiv: Option<String>,
+    pub glx: Option<GlxOpcode>,
+}
+
+pub struct GlxOpcode {
+    pub ty: String,
+    pub opcode: String,
+    pub name: Option<String>,
+}
 
 pub struct Registry {
     pub api: Api,
@@ -56,6 +107,13 @@ impl Registry {
         };
 
         parse::from_xml(src, filter)
+    }
+
+    pub fn write_bindings<W, G>(&self, generator: G, output: &mut W) -> io::Result<()> where
+        G: Generator,
+        W: io::Write,
+    {
+        generator.write(&self, output)
     }
 
     /// Returns a set of all the types used in the supplied registry. This is useful
@@ -135,30 +193,4 @@ impl<'a> Iterator for CmdIterator<'a> {
             }
         })
     }
-}
-
-pub struct Enum {
-    pub ident: String,
-    pub value: String,
-    pub alias: Option<String>,
-    pub ty: Option<String>,
-}
-
-pub struct Binding {
-    pub ident: String,
-    pub ty: String,
-}
-
-pub struct Cmd {
-    pub proto: Binding,
-    pub params: Vec<Binding>,
-    pub alias: Option<String>,
-    pub vecequiv: Option<String>,
-    pub glx: Option<GlxOpcode>,
-}
-
-pub struct GlxOpcode {
-    pub ty: String,
-    pub opcode: String,
-    pub name: Option<String>,
 }

--- a/gl_generator/registry/mod.rs
+++ b/gl_generator/registry/mod.rs
@@ -26,7 +26,7 @@ use Generator;
 
 mod parse;
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Api { Gl, Glx, Wgl, Egl, GlCore, Gles1, Gles2 }
 
 impl fmt::Display for Api {
@@ -43,12 +43,13 @@ impl fmt::Display for Api {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Fallbacks { All, None }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Profile { Core, Compatibility }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Enum {
     pub ident: String,
     pub value: String,
@@ -56,11 +57,13 @@ pub struct Enum {
     pub ty: Option<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Binding {
     pub ident: String,
     pub ty: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Cmd {
     pub proto: Binding,
     pub params: Vec<Binding>,
@@ -69,12 +72,14 @@ pub struct Cmd {
     pub glx: Option<GlxOpcode>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GlxOpcode {
     pub ty: String,
     pub opcode: String,
     pub name: Option<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Registry {
     pub api: Api,
     pub enums: Vec<Enum>,


### PR DESCRIPTION
I originally moved these types to the top level because it was becoming hard to pick them out from the considerably sized registry module. Now that the parsing has been moved into a submodule, it is probably clearer to have the registry types grouped together, then reexported in the top level module.

I also derived some common traits for the registry types.