### PR TITLE
Prevent inlining loadfn too many times

### DIFF
--- a/gl_generator/generators/debug_struct_gen.rs
+++ b/gl_generator/generators/debug_struct_gen.rs
@@ -149,7 +149,11 @@ fn write_impl<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W: i
             /// ~~~
             #[allow(dead_code, unused_variables)]
             pub fn load_with<F>(mut loadfn: F) -> {api} where F: FnMut(&str) -> *const __gl_imports::raw::c_void {{
-                let mut metaloadfn = |symbol: &str, symbols: &[&str]| {{
+                #[inline(never)]
+                fn do_metaloadfn(loadfn: &mut FnMut(&str) -> *const __gl_imports::raw::c_void,
+                                 symbol: &str,
+                                 symbols: &[&str])
+                                 -> *const __gl_imports::raw::c_void {{
                     let mut ptr = loadfn(symbol);
                     if ptr.is_null() {{
                         for &sym in symbols {{
@@ -158,6 +162,9 @@ fn write_impl<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W: i
                         }}
                     }}
                     ptr
+                }}
+                let mut metaloadfn = |symbol: &str, symbols: &[&str]| {{
+                    do_metaloadfn(&mut loadfn, symbol, symbols)
                 }};
                 {api} {{",
         api = super::gen_struct_name(registry.api)

--- a/gl_generator/generators/global_gen.rs
+++ b/gl_generator/generators/global_gen.rs
@@ -192,7 +192,7 @@ fn write_fn_mods<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W
                 }}
 
                 #[allow(dead_code)]
-                pub fn load_with<F>(loadfn: F) where F: FnMut(&str) -> *const raw::c_void {{
+                pub fn load_with<F>(mut loadfn: F) where F: FnMut(&str) -> *const raw::c_void {{
                     unsafe {{
                         storage::{fnname} = FnPtr::new(metaloadfn(&mut loadfn, "{symbol}", {fallbacks}))
                     }}

--- a/gl_generator/generators/global_gen.rs
+++ b/gl_generator/generators/global_gen.rs
@@ -48,10 +48,10 @@ fn write_header<W>(dest: &mut W) -> io::Result<()> where W: io::Write {
 /// Creates the metaloadfn function for fallbacks
 fn write_metaloadfn<W>(dest: &mut W) -> io::Result<()> where W: io::Write {
     writeln!(dest, r#"
-        fn metaloadfn<F>(mut loadfn: F,
-                         symbol: &str,
-                         fallbacks: &[&str]) -> *const __gl_imports::raw::c_void
-                         where F: FnMut(&str) -> *const __gl_imports::raw::c_void {{
+        #[inline(never)]
+        fn metaloadfn(mut loadfn: &mut FnMut(&str) -> *const __gl_imports::raw::c_void,
+                      symbol: &str,
+                      fallbacks: &[&str]) -> *const __gl_imports::raw::c_void {{
             let mut ptr = loadfn(symbol);
             if ptr.is_null() {{
                 for &sym in fallbacks {{
@@ -194,7 +194,7 @@ fn write_fn_mods<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W
                 #[allow(dead_code)]
                 pub fn load_with<F>(loadfn: F) where F: FnMut(&str) -> *const raw::c_void {{
                     unsafe {{
-                        storage::{fnname} = FnPtr::new(metaloadfn(loadfn, "{symbol}", {fallbacks}))
+                        storage::{fnname} = FnPtr::new(metaloadfn(&mut loadfn, "{symbol}", {fallbacks}))
                     }}
                 }}
             }}

--- a/gl_generator/generators/struct_gen.rs
+++ b/gl_generator/generators/struct_gen.rs
@@ -149,7 +149,11 @@ fn write_impl<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W: i
             /// ~~~
             #[allow(dead_code, unused_variables)]
             pub fn load_with<F>(mut loadfn: F) -> {api} where F: FnMut(&str) -> *const __gl_imports::raw::c_void {{
-                let mut metaloadfn = |symbol: &str, symbols: &[&str]| {{
+                #[inline(never)]
+                fn do_metaloadfn(loadfn: &mut FnMut(&str) -> *const __gl_imports::raw::c_void,
+                                 symbol: &str,
+                                 symbols: &[&str])
+                                 -> *const __gl_imports::raw::c_void {{
                     let mut ptr = loadfn(symbol);
                     if ptr.is_null() {{
                         for &sym in symbols {{
@@ -158,6 +162,9 @@ fn write_impl<W>(registry: &Registry, dest: &mut W) -> io::Result<()> where W: i
                         }}
                     }}
                     ptr
+                }}
+                let mut metaloadfn = |symbol: &str, symbols: &[&str]| {{
+                    do_metaloadfn(&mut loadfn, symbol, symbols)
                 }};
                 {api} {{",
         api = super::gen_struct_name(registry.api)


### PR DESCRIPTION
Credit goes to @arielb1, who found this while investigating rust-lang/rust#34166.

This patch also improves compile times of glium using old trans:

Before patch:
```
time: 0.654; rss: 420MB Prepare MIR codegen passes
  time: 1.500; rss: 456MB   write metadata
  time: 0.272; rss: 458MB   translation item collection
  time: 0.047; rss: 459MB   codegen unit partitioning
time: 4.595; rss: 568MB translation
time: 0.004; rss: 568MB assert dep graph
time: 0.000; rss: 568MB serialize dep graph
  time: 1.280; rss: 294MB   llvm function passes [0]
  time: 24.618; rss: 324MB  llvm module passes [0]
  time: 10.087; rss: 322MB  codegen passes [0]
  time: 0.004; rss: 190MB   codegen passes [0]
time: 36.471; rss: 172MB    LLVM passes
time: 0.299; rss: 174MB linking
```

After this patch:
```
time: 0.587; rss: 414MB Prepare MIR codegen passes
  time: 1.396; rss: 459MB   write metadata
  time: 0.265; rss: 460MB   translation item collection
  time: 0.050; rss: 461MB   codegen unit partitioning
time: 4.449; rss: 570MB translation
time: 0.003; rss: 570MB assert dep graph
time: 0.000; rss: 570MB serialize dep graph
  time: 1.271; rss: 292MB   llvm function passes [0]
  time: 20.428; rss: 314MB  llvm module passes [0]
  time: 8.931; rss: 313MB   codegen passes [0]
  time: 0.004; rss: 177MB   codegen passes [0]
time: 31.011; rss: 168MB    LLVM passes
time: 0.257; rss: 169MB linking
```